### PR TITLE
[RDK-6273] Implement non-buffered message approach for write_frame

### DIFF
--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -317,6 +317,7 @@ public:
       , m_internal_state(session::internal_state::USER_INIT)
       , m_msg_manager(new con_msg_manager_type())
       , m_send_buffer_size(0)
+      , m_buffer_messages(true)
       , m_write_flag(false)
       , m_read_flag(true)
       , m_is_server(p_is_server)
@@ -1323,6 +1324,20 @@ public:
      */
     void write_frame();
 
+    /**
+     * This method specifies whether write_frame will send a buffer of messages
+     * to the underlying asio implementation (buffer_messages = true) or if it 
+     * will send each message instantaneously to the underlying asio implementation
+     * (buffer_messages = false).
+     * 
+     * @param buffer_messages Whether in write_frame() to:
+     * - send a buffer of messages (true) - Default
+     * - the message that was just received (false).
+     */
+    void set_messages_to_be_buffered(bool buffer_messages){
+        m_buffer_messages = buffer_messages;
+    }
+
     /// Process the results of a frame write operation and start the next write
     /**
      * \todo unit tests
@@ -1578,6 +1593,9 @@ private:
      * Lock m_write_lock
      */
     std::vector<transport::buffer> m_send_buffer;
+
+    /* Flag used to check if a buffer of messages or just a single message should be sent */
+    bool m_buffer_messages;
 
     /// a list of pointers to hold on to the messages being written to keep them
     /// from going out of scope before the write is complete.

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -1804,15 +1804,23 @@ void connection<config>::write_frame() {
             return;
         }
 
-        // pull off all the messages that are ready to write.
-        // stop if we get a message marked terminal
         message_ptr next_message = write_pop();
-        while (next_message) {
-            m_current_msgs.push_back(next_message);
-            if (!next_message->get_terminal()) {
-                next_message = write_pop();
-            } else {
-                next_message = message_ptr();
+        if (m_buffer_messages) {
+            // pull off all the messages that are ready to write.
+            // stop if we get a message marked terminal
+            while (next_message) {
+                m_current_msgs.push_back(next_message);
+                if (!next_message->get_terminal()) {
+                    next_message = write_pop();
+                } else {
+                    next_message = message_ptr();
+                }
+            }
+        } else {
+            // Immediately send messages if buffering isn't desired
+            if (next_message) {
+                m_elog->write(log::elevel::warn, "Sending non-buffered messages");
+                m_current_msgs.push_back(next_message);
             }
         }
         

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -1819,7 +1819,6 @@ void connection<config>::write_frame() {
         } else {
             // Immediately send messages if buffering isn't desired
             if (next_message) {
-                m_elog->write(log::elevel::warn, "Sending non-buffered messages");
                 m_current_msgs.push_back(next_message);
             }
         }


### PR DESCRIPTION
We noticed that in WiFi throttled environments, that the buffered approach caused message sending performance to degrade substantially for the messages sent to remote clients connected to the web socket server.

After digging into the code, it appears that `write_frame` uses a buffered approach that then transfers buffers of messages to the asio library to send in a thread under the hood. This appears to become substantially non-performant in WiFi throttled environments, even for small sizes of messages.

This `write_frame` method was used to ensure that the websocketpp `send` call is done asynchronously. However, since the implementation of the `WebSocketServer` and `WebSocketClient` use asynchronous threads already to send the messages, this `send` call will not have any blocking repercussions on the application since it is already off of the main thread.

Upon testing sending each message at a time, it appears that the remote observers and the local observers are much more responsive under relaxed and stressed environments given the existing asynchronous nature of the `WebSocketServer`.

Github Issues raise about this topic:
- https://github.com/zaphoyd/websocketpp/issues/391
- https://github.com/zaphoyd/websocketpp/issues/683
- https://github.com/zaphoyd/websocketpp/issues/1036